### PR TITLE
Digi device fix-ups

### DIFF
--- a/scadapass.csv
+++ b/scadapass.csv
@@ -20,7 +20,7 @@ BinTec Elmeg,BinTec R230aw,admin:funwerk,,Router,,http://www.tomshw.it/forum/ban
 BinTec Elmeg,"bintec W2002T-n, ","admin:funwerk, admin:admin",,WLAN Access Point for applications in rolling stocks,,bintec W2002T-n.jpeg
 Contemporary Control Systems,BASRT-B,admin:admin,80/tcp,Router,http,http://www.ccontrols.com/pdf/TD0712000I2.pdf
 Datasensor,UR5i/UR5i SL,root:root,80/tcp,Router,http,http://datasensor.de/sites/datasensor.de/files/datasheets/UR5i_m_e.pdf
-Digi,DC-ME-01T-S,"user:passwd, root:dbps",,Networking Modules,,http://www.digi.com/support/forum/13553/digi-connect-me-default-password
+Digi,DC-ME-01T-S,root:dbps,,Networking Modules,http,http://www.digi.com/support/forum/13553/digi-connect-me-default-password
 Digi,"Digi Connect SP, Digi Connect Wi-SP,  Digi Connect ME,  Digi Connect ME 4 MB, Digi Connect Wi-ME, Digi Connect EM,  Digi Connect Wi-EM",root:dbps,80/tcp,Network Device Server Module,http,http://ftp1.digi.com/support/documentation/90000565_P1.pdf
 Digi,"Digi Connect ES 4/8 SB with Switch, Digi Connect ES 4/8 SB",root:dbps,80/tcp,Concentrator,http,http://ftp1.digi.com/support/documentation/90000565_P1.pdf
 Digi,"ConnectPort TS 4x4, ConnectPort TS 4x2, ConnectPort TS W, ConnectPort TS 8, ConnectPort TS 8 MEI, ConnectPort TS 16",root:dbps,80/tcp,Terminal Server,http,http://ftp1.digi.com/support/documentation/90000565_P1.pdf


### PR DESCRIPTION
Digi DC-ME-01T-S source shows root:dbps, user:pass is a ref to that not separate credentials
DC-ME-01T-S is specifically the HTTP interface per the reference
