### PR TITLE
Emerson Control Link Refrigeration System Controller fix-up

### DIFF
--- a/scadapass.csv
+++ b/scadapass.csv
@@ -35,7 +35,7 @@ Emerson ,Liebert IntelliSlot Web Card ,"Liebert:Liebert, User:User",23/tcp,Web C
 Emerson ,Smart Wireless Gateway 1420,admin:default,80/tcp,Wireless Gateway,http,http://www2.emersonprocess.com/siteadmincenter/PM%20Rosemount%20Documents/00809-0200-4420.pdf
 Emerson ,Network Power® MPH2™ Rack PDU,admin:admin,80/tcp,Rack PDUs,http,https://community.emerson.com/networkpower/support/avocent/power/mph2/m/mediagallery/3093
 Emerson ,UL33 UPS ,123456,,UPS ,,Emerson UL33 UPS.doc
-Emerson ,Control Link Refrigeration System Controller ,0,,Controller ,,http://foodservice.structuralconcepts.com/media/com_sccmanager/temp-controller-info/emerson-control-link-cpc-controller.pdf
+Emerson ,Control Link Refrigeration System Controller ,0000,,Controller ,,http://foodservice.structuralconcepts.com/media/com_sccmanager/temp-controller-info/emerson-control-link-cpc-controller.pdf
 Emerson ,UltraSite,"User 01:100, User 05:200, User 09:300, Engineer:400",,Software,,http://www.emersonclimate.com/Documents/Retail%20Solutions/Manuals/0261004Rev1.pdf
 Emerson ,Avocent® ACS 6000 Advanced Console Server,"admin: avocent, root:linux",,Console Server,"console port, with Telnet, SSH",Emerson Avocent ACS 6000.pdf
 Emerson ,ROCLINK™ 800,LOI:1000,,Software,,http://www.documentation.emersonprocess.com/groups/public/documents/instruction_manuals/d301159x012.pdf


### PR DESCRIPTION
Per referenced manual, default is '0000' not '0'. Imagine Excel or Sheets truncation at work before converting it to GitHub
